### PR TITLE
Replace root logger with module-specific one

### DIFF
--- a/nut2.py
+++ b/nut2.py
@@ -39,7 +39,7 @@ class PyNUTError(Exception):
 class PyNUTClient(object):
     """Access NUT (Network UPS Tools) servers."""
 
-    def __init__(self, host="127.0.0.1", port=3493, login=None, password=None, debug=False, timeout=5, connect=True):
+    def __init__(self, host="127.0.0.1", port=3493, login=None, password=None, timeout=5, connect=True):
         """Class initialization method.
 
         host     : Host to connect (defaults to 127.0.0.1).
@@ -47,15 +47,9 @@ class PyNUTClient(object):
         login    : Login used to connect to NUT server (defaults to None
                    for no authentication).
         password : Password used when using authentication (defaults to None).
-        debug    : Boolean, put class in debug mode (prints everything
-                   on console, defaults to False).
         timeout  : Timeout used to wait for network response (defaults
                    to 5 seconds).
         """
-        if debug:
-            # Print DEBUG messages to the console.
-            logger.setLevel(logging.DEBUG)
-
         logger.debug("Class initialization...")
         logger.debug(" -> Host = %s (port %s)", host, port)
         logger.debug(" -> Login = '%s' / '%s'", login, password)

--- a/tests/test_nutclient.py
+++ b/tests/test_nutclient.py
@@ -3,14 +3,18 @@
 
 # This source code is provided for testing/debuging purpose ;)
 
-from nut2 import PyNUTClient
+import logging
 import sys
 
+import nut2
+from nut2 import PyNUTClient
+
 if __name__ == "__main__" :
+    nut2.logger.setLevel(logging.DEBUG)
 
     print( "PyNUTClient test..." )
-    nut    = PyNUTClient( debug=True )
-    #nut    = PyNUTClient( login="upsadmin", password="upsadmin", debug=True )
+    nut    = PyNUTClient()
+    #nut    = PyNUTClient( login="upsadmin", password="upsadmin" )
 
     print( 80*"-" + "\nTesting 'GetUPSList' :")
     result = nut.GetUPSList( )

--- a/tests/testclient.py
+++ b/tests/testclient.py
@@ -1,21 +1,24 @@
 import unittest
 from mockserver import MockServer
 import telnetlib
+import logging
 try:
     from mock import Mock
 except ImportError:
     from unittest.mock import Mock
 
+import nut2
 from nut2 import PyNUTClient, PyNUTError
 
 class TestClient(unittest.TestCase):
 
     def setUp(self):
-        self.client = PyNUTClient(connect=False, debug=True)
+        nut2.logger.setLevel(logging.DEBUG)
+        self.client = PyNUTClient(connect=False)
         self.client._srv_handler = MockServer(broken=False)
-        self.broken_client = PyNUTClient(connect=False, debug=True)
+        self.broken_client = PyNUTClient(connect=False)
         self.broken_client._srv_handler = MockServer(broken=True)
-        self.not_ok_client = PyNUTClient(connect=False, debug=True)
+        self.not_ok_client = PyNUTClient(connect=False)
         self.not_ok_client._srv_handler = MockServer(ok=False,
                 broken=False)
         self.valid = "test"
@@ -45,7 +48,7 @@ class TestClient(unittest.TestCase):
 
     def test_connect_debug(self):
         try:
-            PyNUTClient(debug=True)
+            PyNUTClient()
         except Exception:
             assert(False)
 
@@ -57,8 +60,7 @@ class TestClient(unittest.TestCase):
 
     def test_connect_credentials(self):
         try:
-            PyNUTClient(login=self.valid, password=self.valid,
-                    debug=True)
+            PyNUTClient(login=self.valid, password=self.valid)
         except TypeError:
             pass
         except PyNUTError:
@@ -69,8 +71,7 @@ class TestClient(unittest.TestCase):
     def test_connect_credentials_username_ok(self):
         try:
             telnetlib.Telnet = MockServer
-            PyNUTClient(login=self.valid, password=self.valid,
-                    debug=True)
+            PyNUTClient(login=self.valid, password=self.valid)
         except TypeError:
             pass
         except PyNUTError:
@@ -229,7 +230,7 @@ class TestClient(unittest.TestCase):
                 self.valid, self.valid)
 
     def test_list_enum(self):
-        self.assertEquals(self.client.list_enum(self.valid, self.valid), 
+        self.assertEquals(self.client.list_enum(self.valid, self.valid),
                 [self.valid_desc])
 
     def test_list_enum_broken(self):
@@ -237,7 +238,7 @@ class TestClient(unittest.TestCase):
                 self.valid, self.valid)
 
     def test_list_range(self):
-        self.assertEquals(self.client.list_range(self.valid, self.valid), 
+        self.assertEquals(self.client.list_range(self.valid, self.valid),
                 [self.valid_desc])
 
     def test_list_range_broken(self):
@@ -245,7 +246,7 @@ class TestClient(unittest.TestCase):
                 self.valid, self.valid)
 
     def test_var_type(self):
-        self.assertEquals(self.client.var_type(self.valid, self.valid), 
+        self.assertEquals(self.client.var_type(self.valid, self.valid),
                 "RW STRING:3")
 
     def test_var_type_broken(self):


### PR DESCRIPTION
Logging via the root logger is a discouraged behaviour, since the end-user does not have a way to influence the level and handlers (and other details) of log messages of the specific module. [See here.](https://docs.python-guide.org/writing/logging/#logging-in-a-library)

In this PR, I replace the `logging` calls with calls on a module level logger instance.